### PR TITLE
Update to Sandpack dependencies following Chakra V3 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.7.1",
     "react-router-dom": "^6.8.0",
-    "sort-by": "^1.2.0",
     "use-debounce": "^9.0.3"
   },
   "devDependencies": {

--- a/src/components/sandpack-provider.tsx
+++ b/src/components/sandpack-provider.tsx
@@ -21,14 +21,14 @@ export const SandpackProvider = ({ children, code }: SandpackProps) => (
     }}
     customSetup={{
       dependencies: {
-        '@chakra-ui/react': 'latest',
-        '@chakra-ui/icons': 'latest',
-        '@chakra-ui/anatomy': 'latest',
-        '@chakra-ui/styled-system': 'latest',
-        '@emotion/styled': 'latest',
-        '@emotion/react': 'latest',
-        'framer-motion': 'latest',
-        'react-icons': 'latest',
+        '@chakra-ui/react': '^2.8.2',
+        '@chakra-ui/icons': '^2.1.1',
+        '@chakra-ui/anatomy': 'v2-latest',
+        '@chakra-ui/styled-system': 'v2-latest',
+        '@emotion/styled': '^11.10.5',
+        '@emotion/react': '^11.10.5',
+        'framer-motion': '^8.5.0',
+        'react-icons': '^4.7.1',
       },
     }}
     files={{


### PR DESCRIPTION
## Description
Following the release of Chakra V3, this playground no longer works (since the theme setup is based on V2).

## Changes
- Locked Sandpack dependencies to working Chakra V2 versions. 
- Removed sort-by package (depends on unsafe object-path version)
- Also solves #11 